### PR TITLE
Lazily require symbols

### DIFF
--- a/slug.js
+++ b/slug.js
@@ -1,9 +1,11 @@
 /* eslint-disable */
-const _symbols = require('./unicode/So');
+let _symbols;
 const removeList = ['sign','cross','of','symbol','staff','hand','black','white']
         .map(function (word) {return new RegExp(word, 'gi')});
 
 function symbols(code) {
+    if (_symbols == null)
+        _symbols = require('./unicode/So');
     return _symbols[code];
 }
 


### PR DESCRIPTION
This reduces overhead at require time and only impacts performance if symbols are actually used